### PR TITLE
FIX : [BUG]  : Docker Build Fails

### DIFF
--- a/solaris/environment-gpu.yml
+++ b/solaris/environment-gpu.yml
@@ -14,7 +14,7 @@ dependencies:
   - matplotlib>=3.1.2
   - networkx>=2.4
   - opencv>=4.1
-  - pandas>=0.25.3
+  - pandas>=0.25.3,<=1.5.3
   - pyproj>=2.1
   - pytorch>=1.3.1
   - pyyaml=5.2

--- a/solaris/environment.yml
+++ b/solaris/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - networkx>=2.4
   - numpy>=1.17.3
   - opencv>=4.1
-  - pandas>=0.25.3
+  - pandas>=0.25.3,<=1.5.3
   - pyproj>=2.1
   - pytorch>=1.3.1
   - pyyaml=5.2

--- a/solaris/requirements.txt
+++ b/solaris/requirements.txt
@@ -8,7 +8,7 @@ matplotlib>=3.1.2
 networkx>=2.4
 numpy>=1.17.3
 opencv-python>=4.1
-pandas>=0.25.3
+pandas>=0.25.3,<=1.5.3
 pyproj>=2.1
 torch>=1.3.1
 pyyaml==5.2

--- a/solaris/setup.py
+++ b/solaris/setup.py
@@ -69,7 +69,7 @@ else:
                  'networkx>=2.4',
                  'numpy>=1.17.3',
                  'opencv-python>=4.1',
-                 'pandas>=0.25.3',
+                 'pandas>=0.25.3,<=1.5.3',
                  'pyproj>=2.1',
                  'pyyaml>=5.2',
                  'rasterio>=1.0.23',


### PR DESCRIPTION
This PR Updates pandas version and restrict it to 1.5.3 & Fixes the docker build

**How to reproduce the bug :** 

- Simply try to build docker image from scratch you will see following error 

```
Processing labels in directory: /tf/data/output/raw_polygonized_buildings
  0%|          | 0/84 [00:00<?, ?it/s]e_v1_gpu-1  | 
  0%|          | 0/84 [00:00<?, ?it/s]e_v1_gpu-1  | 
model_ramp_baseline-model_ramp_baseline_v1_gpu-1  | Traceback (most recent call last):
model_ramp_baseline-model_ramp_baseline_v1_gpu-1  |   File "model_ramp_baseline/remove_slivers.py", line 153, in <module>
model_ramp_baseline-model_ramp_baseline_v1_gpu-1  |     main()
model_ramp_baseline-model_ramp_baseline_v1_gpu-1  |   File "model_ramp_baseline/remove_slivers.py", line 128, in main
model_ramp_baseline-model_ramp_baseline_v1_gpu-1  |     count_data = filter_label_file_by_size(min_size, str(lf), str(outfile))
model_ramp_baseline-model_ramp_baseline_v1_gpu-1  |   File "model_ramp_baseline/remove_slivers.py", line 77, in filter_label_file_by_size
model_ramp_baseline-model_ramp_baseline_v1_gpu-1  |     vdf_filtered.to_file(out_path, driver="GeoJSON")
model_ramp_baseline-model_ramp_baseline_v1_gpu-1  |   File "/usr/local/lib/python3.8/dist-packages/geopandas/geodataframe.py", line 1114, in to_file
model_ramp_baseline-model_ramp_baseline_v1_gpu-1  |     _to_file(self, filename, driver, schema, index, **kwargs)
model_ramp_baseline-model_ramp_baseline_v1_gpu-1  |   File "/usr/local/lib/python3.8/dist-packages/geopandas/io/file.py", line 362, in _to_file
model_ramp_baseline-model_ramp_baseline_v1_gpu-1  |     pd.Int64Index,
model_ramp_baseline-model_ramp_baseline_v1_gpu-1  | AttributeError: module 'pandas' has no attribute 'Int64Index'
```

**Reason  of error :** 

Pandas made huge upgrade after 2> version and no longer support Int64Index code  

https://pandas.pydata.org/pandas-docs/stable/whatsnew/v2.0.0.html#index-can-now-hold-numpy-numeric-dtypes 

**Solution**: 
I have restricted python to install newer version , I have added 1.5.3 specifically because that's the optimal version  
 I found with multiple hit and trials which doesn't raises any other conflict on existing lib that Ramp uses 